### PR TITLE
Upgrade yaml dot net to 8.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Desh is a concise and readable language to describe business rules.
 ## How to use
 Just install the [Desh NuGet package](https://www.nuget.org/packages/desh/):
 ```
-PM> Install-Package YamlDotNet
+PM> Install-Package desh
 ```
 Craft a Desh document (YAML).
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 # version format
-version: 0.2.{build}
+version: 0.3.{build}
 
 # you can use {branch} name in version format too
 # version: 1.0.{build}-{branch}

--- a/src/Desh.Test/Desh.Test.csproj
+++ b/src/Desh.Test/Desh.Test.csproj
@@ -15,10 +15,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Desh.Test/DesiredFeatures.cs
+++ b/src/Desh.Test/DesiredFeatures.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Xunit;
 
 namespace Desh.Test

--- a/src/Desh.Test/ParseExecuteTestRunner.cs
+++ b/src/Desh.Test/ParseExecuteTestRunner.cs
@@ -1,9 +1,8 @@
-﻿using System;
+﻿using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Security.Cryptography;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
 using Xunit;
 
 namespace Desh.Test

--- a/src/Desh.Test/SmokeDeshParsingAndExecution.cs
+++ b/src/Desh.Test/SmokeDeshParsingAndExecution.cs
@@ -1,11 +1,4 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
-using Desh.Execution;
-using Desh.Parsing;
-using Newtonsoft.Json;
 using Xunit;
 
 namespace Desh.Test

--- a/src/Desh.Test/TestAirplaneFuelChoice.cs
+++ b/src/Desh.Test/TestAirplaneFuelChoice.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using Xunit;
 

--- a/src/Desh.Test/TestDocumentationExample.cs
+++ b/src/Desh.Test/TestDocumentationExample.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
 using Xunit;
 

--- a/src/Desh.Test/TestServiceLevelAgreement.cs
+++ b/src/Desh.Test/TestServiceLevelAgreement.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using Xunit;
 

--- a/src/Desh.Test/YamlTestReader.cs
+++ b/src/Desh.Test/YamlTestReader.cs
@@ -16,7 +16,7 @@ namespace Desh.Test
             var deserializer =
                 new DeserializerBuilder()
                     .WithNodeDeserializer(new TestCaseWithSourceDeserializer{Resource = filename })
-                    .WithNamingConvention(new CamelCaseNamingConvention())
+                    .WithNamingConvention(CamelCaseNamingConvention.Instance)
                     .Build();
             var testCases = deserializer.Deserialize<List<TestCaseWithSource>>(File.ReadAllText(filename));
             foreach (var testCase in testCases)

--- a/src/Desh.Test/YamlTestReader.cs
+++ b/src/Desh.Test/YamlTestReader.cs
@@ -1,12 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Text;
-using Desh.Parsing;
-using Desh.Parsing.Ast;
 using Xunit;
 using YamlDotNet.Core;
-using YamlDotNet.Core.Events;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
 

--- a/src/Desh/Desh.csproj
+++ b/src/Desh/Desh.csproj
@@ -7,7 +7,6 @@
     <Product>desh.net</Product>
     <Company>IvanAkcheurov</Company>
     <Authors>Ivan Akcheurov</Authors>
-    <Version>0.1.1</Version>
     <Copyright>(c) Ivan Akcheurov</Copyright>
     <RepositoryUrl>https://github.com/ivanakcheurov/desh.net</RepositoryUrl>
     <RepositoryType>GitHub</RepositoryType>

--- a/src/Desh/Desh.csproj
+++ b/src/Desh/Desh.csproj
@@ -29,7 +29,7 @@ desh (Decision Expressions) is a concise language for defining business rules.</
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="YamlDotNet.Signed" Version="5.3.0" />
+    <PackageReference Include="YamlDotNet" Version="8.1.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Desh/Execution/Logging/IExecutionLogger.cs
+++ b/src/Desh/Execution/Logging/IExecutionLogger.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace Desh.Execution.Logging
+﻿namespace Desh.Execution.Logging
 {
     public interface IExecutionLogger
     {

--- a/src/Desh/Execution/Logging/Log.cs
+++ b/src/Desh/Execution/Logging/Log.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
 using YamlDotNet.Core;
 using YamlDotNet.Serialization;
 

--- a/src/Desh/Execution/Logging/Step.cs
+++ b/src/Desh/Execution/Logging/Step.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using YamlDotNet.Serialization;
 
 namespace Desh.Execution.Logging

--- a/src/Desh/Execution/Logging/StepType.cs
+++ b/src/Desh/Execution/Logging/StepType.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace Desh.Execution.Logging
+﻿namespace Desh.Execution.Logging
 {
     public enum StepType
     {

--- a/src/Desh/OutOfTheBox/DeshFacade.cs
+++ b/src/Desh/OutOfTheBox/DeshFacade.cs
@@ -1,12 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Desh.Execution;
+﻿using Desh.Execution;
 using Desh.OutOfTheBox;
 using Desh.Parsing;
 using Desh.Parsing.Ast;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 using YamlDotNet.Serialization;
 
 // ReSharper disable once CheckNamespace

--- a/src/Desh/OutOfTheBox/ExecutionLogger.cs
+++ b/src/Desh/OutOfTheBox/ExecutionLogger.cs
@@ -13,7 +13,6 @@ namespace Desh.OutOfTheBox
     {
         private readonly Log _log;
         private readonly Dictionary<int, Step> _logSteps = new Dictionary<int, Step>();
-        private int _currentStepNumber = 1;
 
         public ExecutionLogger()
         {

--- a/src/Desh/OutOfTheBox/ExecutionLogger.cs
+++ b/src/Desh/OutOfTheBox/ExecutionLogger.cs
@@ -1,12 +1,11 @@
-﻿using System;
+﻿using Desh.Execution;
+using Desh.Execution.Logging;
+using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using System.Security.Cryptography;
 using System.Text;
-using Desh.Execution;
-using Desh.Execution.Logging;
 
 namespace Desh.OutOfTheBox
 {

--- a/src/Desh/OutOfTheBox/LambdaOperatorEvaluator.cs
+++ b/src/Desh/OutOfTheBox/LambdaOperatorEvaluator.cs
@@ -1,8 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Desh.Execution;
+﻿using Desh.Execution;
 using Desh.Parsing;
+using System;
+using System.Collections.Generic;
 
 namespace Desh.OutOfTheBox
 {

--- a/src/Desh/OutOfTheBox/LambdaVariableEvaluator.cs
+++ b/src/Desh/OutOfTheBox/LambdaVariableEvaluator.cs
@@ -1,9 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading.Tasks;
-using Desh.Execution;
+﻿using Desh.Execution;
 using Desh.Parsing;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace Desh.OutOfTheBox
 {

--- a/src/Desh/OutOfTheBox/StandardOperators.cs
+++ b/src/Desh/OutOfTheBox/StandardOperators.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Text;
 using System.Linq;
 
 namespace Desh.OutOfTheBox

--- a/src/Desh/Parsing/Ast/Node.cs
+++ b/src/Desh/Parsing/Ast/Node.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using YamlDotNet.Serialization;
+﻿using YamlDotNet.Serialization;
 
 namespace Desh.Parsing.Ast
 {

--- a/src/Desh/Parsing/Ast/Variable.cs
+++ b/src/Desh/Parsing/Ast/Variable.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Desh.Parsing.Ast
 {

--- a/src/Desh/Parsing/DeshParser.cs
+++ b/src/Desh/Parsing/DeshParser.cs
@@ -30,7 +30,7 @@ namespace Desh.Parsing
                 builder = builder.WithNodeDeserializer(nodeDeserializer);
             }
             var deserializer =
-                builder.WithNamingConvention(new CamelCaseNamingConvention())
+                builder.WithNamingConvention(CamelCaseNamingConvention.Instance)
                     .Build();
 
             //Dictionary<string, string[]> map;
@@ -39,7 +39,7 @@ namespace Desh.Parsing
                 var eventReader = new Parser(reader);
                 // Consume the stream start event "manually"
                 // https://stackoverflow.com/questions/27490434/does-yamldotnet-library-support-the-document-separator
-                eventReader.Expect<StreamStart>();
+                eventReader.Consume<StreamStart>();
                 //map = deserializer.Deserialize<Dictionary<string, string[]>>(eventReader);
                 var decisionTree = deserializer.Deserialize<ExpressionBlock>(eventReader);
                 return decisionTree;
@@ -91,8 +91,8 @@ namespace Desh.Parsing
         public override bool Deserialize(YamlDotNet.Core.IParser reader, Func<YamlDotNet.Core.IParser, Type, object> nestedObjectDeserializer, out ExpressionBlock value)
         {
             var _ = reader.Current.Start;
-            var seq = reader.Peek<SequenceStart>();
-            if (seq != null)
+
+            if (reader.Accept<SequenceStart>(out var seq))
             {
                 // OR list of Expression_AND_Mapping
                 var expressionAndMappings = (Expression_AND_Mapping[])nestedObjectDeserializer(reader, typeof(Expression_AND_Mapping[]));
@@ -101,8 +101,7 @@ namespace Desh.Parsing
                 return true;
             }
 
-            var scalar = reader.Peek<Scalar>();
-            if (scalar != null)
+            if (reader.Accept<Scalar>(out var _))
             {
                 value = (DecisionLeaf)nestedObjectDeserializer(reader, typeof(DecisionLeaf));
                 return true;
@@ -120,7 +119,7 @@ namespace Desh.Parsing
         {
             var _ = reader.Current.Start;
             // ReSharper disable once UnusedVariable, used for debugging purposes
-            var map = reader.Expect<MappingStart>();
+            var map = reader.Consume<MappingStart>();
 
             var pairs = new Dictionary<Variable, Comparator>();
             ExpressionBlock thenBlock = null;
@@ -128,7 +127,7 @@ namespace Desh.Parsing
             MappingEnd end;
             do
             {
-                var variableScalar = reader.Expect<Scalar>();
+                var variableScalar = reader.Consume<Scalar>();
                 switch (variableScalar.Value)
                 {
                     case "anyIsTrue":
@@ -165,7 +164,7 @@ namespace Desh.Parsing
                         break;
                 }
 
-            } while ((end = reader.Allow<MappingEnd>()) == null);
+            } while (!reader.TryConsume(out end));
 
             //var check = new Check(variableName, comparators);
             value = new Expression_AND_Mapping(SourceDesh, Extensions.ToDeshSpan(map, end)) { NormalPairs = pairs, ThenExpressionBlock = thenBlock, DecisionLeaf = decision };
@@ -179,8 +178,7 @@ namespace Desh.Parsing
         public override bool Deserialize(YamlDotNet.Core.IParser reader, Func<YamlDotNet.Core.IParser, Type, object> nestedObjectDeserializer, out Comparator value)
         {
             var _ = reader.Current.Start;
-            var seq = reader.Allow<SequenceStart>();
-            if (seq != null)
+            if (reader.TryConsume<SequenceStart>(out var seq))
             {
                 // OR list of Expression_AND_Mapping
                 var comparators = new List<Comparator>();
@@ -191,14 +189,13 @@ namespace Desh.Parsing
                     var comp = (Comparator)nestedObjectDeserializer(reader, typeof(Comparator));
                     comparators.Add(comp);
                     // ReSharper disable once RedundantAssignment
-                } while ((endCond = reader.Allow<SequenceEnd>()) == null);
+                } while (!reader.TryConsume(out endCond));
 
                 value = new ComparatorOrList (SourceDesh, Extensions.ToDeshSpan(seq, endCond)) { Comparators = comparators.ToArray()};
                 return true;
             }
 
-            var scalar = reader.Allow<Scalar>();
-            if (scalar != null)
+            if (reader.TryConsume<Scalar>(out var scalar))
             {
                 if (Ctx.OperatorRecognizer.Recognize(scalar.Value))
                     value = new UnaryOperator(SourceDesh, scalar.ToDeshSpan()) { Name = scalar.Value };
@@ -207,14 +204,13 @@ namespace Desh.Parsing
                 return true;
             }
 
-            var unused = reader.Expect<MappingStart>();
-            var variableOrOperatorScalar = reader.Peek<Scalar>();
-            if (variableOrOperatorScalar?.Value != null && Ctx.OperatorRecognizer.Recognize(variableOrOperatorScalar.Value))
+            reader.Consume<MappingStart>();
+            if (reader.Accept<Scalar>(out var variableOrOperatorScalar) && variableOrOperatorScalar.Value != null && Ctx.OperatorRecognizer.Recognize(variableOrOperatorScalar.Value))
                 value = (Operator_AND_Mapping)nestedObjectDeserializer(reader, typeof(Operator_AND_Mapping));
             else
                 value = (ValueExpressionTree)nestedObjectDeserializer(reader, typeof(ValueExpressionTree));
 
-            var unused1 = reader.Expect<MappingEnd>();
+            reader.Consume<MappingEnd>();
             return true;
         }
         public ComparatorDeserializer(IContext ctx) : base(ctx) { }
@@ -233,19 +229,19 @@ namespace Desh.Parsing
             MappingEnd end;
             do
             {
-                var scalar = reader.Peek<Scalar>();
+                reader.Accept<Scalar>(out var scalar);
                 switch (scalar.Value)
                 {
                     case "then":
                         if (thenBlock != null)
                             throw new ParseException("Cannot have two THEN blocks");
-                        var unused = reader.Expect<Scalar>();
+                        reader.Consume<Scalar>();
                         thenBlock = (ExpressionBlock)nestedObjectDeserializer(reader, typeof(ExpressionBlock));
                         break;
                     case "decide":
                         if (decision != null)
                             throw new ParseException("Cannot have multiple DECIDE blocks");
-                        var unused1 = reader.Expect<Scalar>();
+                        reader.Consume<Scalar>();
                         decision = (DecisionLeaf)nestedObjectDeserializer(reader, typeof(DecisionLeaf));
                         break;
                     default:
@@ -253,7 +249,7 @@ namespace Desh.Parsing
                         operators.Add(@operator);
                         break;
                 }
-            } while ((end = reader.Peek<MappingEnd>()) == null);
+            } while (!reader.Accept(out end));
 
             value = new Operator_AND_Mapping(operators.ToArray(), thenBlock, decision, SourceDesh, Extensions.ToDeshSpan(_, end));
             return true;
@@ -268,20 +264,18 @@ namespace Desh.Parsing
         {
             var _ = reader.Current;
             List<ScalarValue> scalars = new List<ScalarValue>();
-            var seq = reader.Allow<SequenceStart>();
-            if (seq != null)
+            if (reader.TryConsume<SequenceStart>(out var _))
             {
-                SequenceEnd seqEnd;
                 do
                 {
-                    var scalar = reader.Expect<Scalar>();
+                    var scalar = reader.Consume<Scalar>();
                     scalars.Add(new ScalarValue(SourceDesh, scalar.ToDeshSpan()){Value = scalar.Value});
                 }
-                while ((seqEnd = reader.Allow<SequenceEnd>()) == null);
+                while (!reader.TryConsume(out SequenceEnd _));
             }
             else
             {
-                var scalar = reader.Expect<Scalar>();
+                var scalar = reader.Consume<Scalar>();
                 scalars.Add(new ScalarValue(SourceDesh, scalar.ToDeshSpan()) { Value = scalar.Value });
             }
 
@@ -298,7 +292,7 @@ namespace Desh.Parsing
         public override bool Deserialize(YamlDotNet.Core.IParser reader, Func<YamlDotNet.Core.IParser, Type, object> nestedObjectDeserializer, out DecisionLeaf value)
         {
             var _ = reader.Current.Start;
-            var decisionScalar = reader.Expect<Scalar>();
+            var decisionScalar = reader.Consume<Scalar>();
             value = new DecisionLeaf (SourceDesh, decisionScalar.ToDeshSpan()) { Decision = decisionScalar.Value };
             return true;
         }
@@ -310,18 +304,18 @@ namespace Desh.Parsing
         public override bool Deserialize(YamlDotNet.Core.IParser reader, Func<YamlDotNet.Core.IParser, Type, object> nestedObjectDeserializer, out Operator value)
         {
             var _ = reader.Current.Start;
-            var operatorNameScalar = reader.Expect<Scalar>();
+            var operatorNameScalar = reader.Consume<Scalar>();
             var operatorName = operatorNameScalar.Value;
             if (Ctx.OperatorRecognizer.Recognize(operatorName) == false)
                 throw new ParseException("Must be an operator name");
             string[] args = null;
-            if (reader.Peek<SequenceStart>() != null)
+            if (reader.Accept<SequenceStart>(out var _))
             {
                 args = (string[])nestedObjectDeserializer(reader, typeof(string[]));
             }
             else
             {
-                var arg = reader.Expect<Scalar>().Value;
+                var arg = reader.Consume<Scalar>().Value;
                 if (arg != null)
                     args = new[] { arg };
             }

--- a/src/Desh/Parsing/DeshParser.cs
+++ b/src/Desh/Parsing/DeshParser.cs
@@ -1,8 +1,7 @@
-﻿using System;
+﻿using Desh.Parsing.Ast;
+using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using Desh.Parsing.Ast;
 using YamlDotNet.Core;
 using YamlDotNet.Core.Events;
 using YamlDotNet.Serialization;

--- a/src/Desh/Parsing/Extensions.cs
+++ b/src/Desh/Parsing/Extensions.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using YamlDotNet.Core.Events;
+﻿using YamlDotNet.Core.Events;
 
 namespace Desh.Parsing
 {

--- a/src/Desh/Parsing/IContext.cs
+++ b/src/Desh/Parsing/IContext.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace Desh.Parsing
+﻿namespace Desh.Parsing
 {
     public interface IContext
     {

--- a/src/Desh/Parsing/INameRecognizer.cs
+++ b/src/Desh/Parsing/INameRecognizer.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace Desh.Parsing
+﻿namespace Desh.Parsing
 {
     public interface INameRecognizer
     {

--- a/src/Desh/Parsing/IParseLogger.cs
+++ b/src/Desh/Parsing/IParseLogger.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace Desh.Parsing
+﻿namespace Desh.Parsing
 {
     public interface IParseLogger
     {


### PR DESCRIPTION
- Upgrade all dependencies (nugets)
- Remove unused variables and namespaces
- Upgrade YamlDotNet usage (Obsolete warnings, see [Release notes](https://github.com/aaubry/YamlDotNet/releases))